### PR TITLE
fix(post): fix the reversed problem for next and prev buttons

### DIFF
--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -5,17 +5,17 @@
     <!-- 前后页  -->
     <ul class="post-pager">
         <% if (page.prev){ %>
-            <li class="next">
+            <li class="previous">
                 <a href= "<%- url_for(page.prev.path) %>" title= <%- page.prev.title %> >
-                    <span>Next Post</span>
+                    <span>Previous Post</span>
                     <span><%- page.prev.title || '[Untitled Post]' %></span>
                 </a>
             </li>
         <% } %>
         <% if (page.next){ %>
-            <li class="previous">
+            <li class="next">
                 <a href= "<%- url_for(page.next.path) %>" title= <%- page.next.title %> >
-                    <span>Previous Post</span>
+                    <span>Next Post</span>
                     <span><%- page.next.title || '[Untitled Post]' %></span>
                 </a>
             </li>


### PR DESCRIPTION
Ooop, it's an obvious mistake in post page that next button and prev button have mussy classname and plain text.
Fixed it. Otherwise, it will make lots of users confused.