### PR TITLE
允许用户手动指定文章的副标题

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -1,7 +1,8 @@
 <main class="main index-page">
     <% page.posts.each(function (_post) { %>
     <% let truncateLength = typeof theme.truncate_length === 'number' ? theme.truncate_length : 300 %>
-    <% let _content = truncateLength === 0 ? null : truncate(strip_html(_post.content), {length: truncateLength, omission: '...'}) %>
+    <% let _content = !!_post.abstract ? _post.abstract : 
+        (truncateLength === 0 ? null : truncate(strip_html(_post.content), {length: truncateLength, omission: '...'})) %>
         <article class="index-post">
             <a class="abstract-title" href = "<%- url_for(_post.path) %>" >
                 <% if(_post.top) { %>


### PR DESCRIPTION
发现这个主题没有允许用户手动指定文章的副标题的功能，就尝试添加了一下