### PR TITLE
Fix author with special chars

### DIFF
--- a/layout/site-meta.ejs
+++ b/layout/site-meta.ejs
@@ -1,6 +1,6 @@
 <script>
     var siteMeta = {
         root: '<%- config.root %>',
-        author: '<%- config.author %>'
+        author: '<%= config.author %>'
     }
 </script>


### PR DESCRIPTION
In my surname there is the apostrophe character [ -> ' <- ] and the theme was misbehaving (and there were errors in the console).
By escaping the variable the problem goes away.

Maybe it could be better to use quotes to enclose this variable, but at the moment I am not able to test it. This pull request is mostly to report the issue.