### PR TITLE
Generate html description meta with open_graph()

### DIFF
--- a/layout/_partial/base-head.ejs
+++ b/layout/_partial/base-head.ejs
@@ -21,7 +21,7 @@
     <% } else { %>
     <meta name="keywords" content="<%- config.title %>,<%- config.author %>">
     <% } %>
-    <meta name="description" content="<%- config.description %>">
+    <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
     <meta http-equiv="Cache-control" content="no-cache">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
     <title><%= title %></title>


### PR DESCRIPTION
Description meta info can be auto-generated with open_graph() if it is not set in post configs.

Adding [OpenGraph](http://ogp.me/) meta info to your site can help other apps like google and twitter to understand your site's content better.

https://github.com/hexojs/hexo-theme-landscape/blob/master/layout/_partial/head.ejs#L25