### PR TITLE
修正CNZZ统计代码

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -61,7 +61,15 @@
     <!-- CNZZ  -->
     <% if (theme.CNZZ_analytics) { %>
     <div style="display: none">
-        <script src="https://s13.cnzz.com/z_stat.php?id=<%- theme.CNZZ_analytics %>&web_id=<%- theme.CNZZ_analytics %>" language="JavaScript"></script>
+        <script>
+            var cnzz_s_tag = document.createElement('script');
+            cnzz_s_tag.type = 'text/javascript';
+            cnzz_s_tag.async = true;
+            cnzz_s_tag.charset = 'utf-8';
+            cnzz_s_tag.src = 'https://w.cnzz.com/c.php?id=<%- theme.CNZZ_analytics %>&async=1';
+            var root_s = document.getElementsByTagName('script')[0];
+            root_s.parentNode.insertBefore(cnzz_s_tag, root_s);
+        </script>
         <% } %>
     </div>
     <!-- async load share.js -->


### PR DESCRIPTION
Chrome浏览器Console出现警告：阻止跨站解析器阻断脚本通过document.write调用（A parser-blocking,cross site script,XXXX.js is invoked via document.write.）。
根据https://www.freebuf.com/company-information/174302.html
进行代码的修正测试可用