### PR TITLE
Add Mathjax to support LaTeX math formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ npm uninstall hexo-renderer-marked --save
 npm install hexo-renderer-kramed --save
 ```
 
+然后就可以配置每篇文章(即.md文件)的头部的`mathjax: true`字段来实现在本篇文章中启用LaTex公式支持。
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ about_intro_height: 50
 
 首先备份 archer 下所有你自定义过的文件（包括 _config.yml 和 source 文件夹下添加的文件等），然后删除 archer，再重新安装，最后将备份的文件替换到原来的位置即可。
 
+## 关于LaTeX支持
+
+已经内置mathjax.js，但是需要替换默认的渲染引擎来支持解析LaTeX语法。
+```bash
+npm uninstall hexo-renderer-marked --save
+npm install hexo-renderer-kramed --save
+```
+
 ## License
 
 MIT

--- a/_config.yml
+++ b/_config.yml
@@ -129,3 +129,8 @@ copyright:
   enable: true
   # https://creativecommons.org/
   license: '本文采用<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">知识共享署名-非商业性使用 4.0 国际许可协议</a>进行许可'
+
+# MathJax Support
+mathjax:
+  enable: true
+  cdn: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS-MML_HTMLorMML

--- a/layout/mathjax.ejs
+++ b/layout/mathjax.ejs
@@ -1,0 +1,29 @@
+<% if (theme.mathjax.enable){ %>
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+          tex2jax: {
+            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+            processEscapes: true
+          }
+        });
+      </script>
+
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+            tex2jax: {
+              skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+            }
+          });
+      </script>
+
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Queue(function() {
+              var all = MathJax.Hub.getAllJax(), i;
+              for(i=0; i < all.length; i += 1) {
+                  all[i].SourceElement().parentNode.className += ' has-jax';
+              }
+          });
+      </script>
+
+    <script type="text/javascript" src="<%- theme.mathjax.cdn %>"></script>
+<% } %>

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -1,4 +1,7 @@
 <main class="main post-page">
+    <% if (page.mathjax == true){ %>
+        <%- partial('mathjax') %>
+    <% } %>
     <article class="article-entry">
         <%- page.content %>
     </article>


### PR DESCRIPTION
According to [给Hexo主题添加LaTeX公式支持](https://adores.cc/posts/62947.html), I added `mathjax.ejs`, modified `post.ejs` and appended configurations to `_config.yml`. I also added some brief instructions to README.