### PR TITLE
fix: in dark theme, gitalk comment container has close color and background-color

### DIFF
--- a/source/css/dark.css
+++ b/source/css/dark.css
@@ -1,7 +1,494 @@
-:root{--base-font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial,
-    'PingFang SC', 'Hiragino Sans GB', STHeiti, 'Microsoft YaHei',
-    'Microsoft JhengHei', 'Source Han Sans SC', 'Noto Sans CJK SC',
-    'Source Han Sans CN', 'Noto Sans SC', 'Source Han Sans TC',
-    'Noto Sans CJK TC', 'WenQuanYi Micro Hei', SimSun, sans-serif}@font-face{font-family:'iconfont-archer';src:url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.eot");src:url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.eot?#iefix") format("embedded-opentype"),url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.woff") format("woff"),url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.ttf") format("truetype"),url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.svg#iconfont-archer") format("svg")}.iconfont-archer{font-family:'iconfont-archer' !important;font-size:1rem;font-style:normal;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}body{background-color:#121212}.background-holder{background-color:#121212}.container{background-color:#121212}::-moz-selection{background:#f75357;color:snow}::selection{background:#f75357;color:snow}.note{background-color:#1e1e1e !important}.back-top{border-color:rgba(255,255,255,0.87);background-color:rgba(18,18,18,0.8);color:rgba(255,255,255,0.87)}.back-top:hover{background-color:rgba(255,255,255,0.87);color:#121212}.back-top-rounded{color:#fff;background-color:#121212}.back-top-rounded:hover{color:#333}.footer{background-color:#121212}.copyright a{color:#f75357}#busuanzi_container_site_pv,#busuanzi_container_site_uv{color:rgba(255,255,255,0.38)}.read-progress{background-color:rgba(255,255,255,0.6)}.read-progress-feature{background-color:#f75357}.banner{border-bottom-color:rgba(255,255,255,0.87);background-color:rgba(0,0,0,0.8)}.banner .blog-title a{color:rgba(255,255,255,0.87)}.banner .blog-title a:hover{color:#f75357}.banner .post-title a{color:rgba(255,255,255,0.87)}.banner.banner-clean{background-color:rgba(0,0,0,0.9)}.header-sidebar-menu{border-color:#fff;color:#fff}.header-sidebar-menu:hover{background-color:#fff;color:#000}.header-sidebar-menu-rounded:hover{background-color:transparent;color:#f75357}.header-sidebar-menu-black{color:rgba(255,255,255,0.87);background-color:#121212;border-color:rgba(255,255,255,0.87)}.header-sidebar-menu-black:hover{background-color:rgba(255,255,255,0.87);color:#121212}.header-actions .home-link a:hover{color:#f75357}.profile{color:#777;border-color:rgba(255,255,255,0.1)}.profile-avatar{border-color:rgba(255,255,255,0.1)}.profile-name{color:#ddd}.profile-social{border-color:rgba(255,255,255,0.1)}.friends{border-color:rgba(255,255,255,0.1)}.friends a{color:#777}.friends a:hover{color:#f75357}.profile-link-item{border-color:rgba(255,255,255,0.1)}.profile-link-item a{color:#777}.profile-link-item a:hover{color:#f75357}.popup{background:#121212;color:#e1e1e1;box-shadow:0px 0px 10px rgba(255,255,255,0.5)}.algolia-search{border-bottom-color:#222;background-color:#181818}.algolia-search-input input{color:rgba(255,255,255,0.87)}.algolia-hit-item:hover{border-bottom:1px solid;background-color:#181818}.algolia-hit-item-link{color:rgba(255,255,255,0.87)}.popup-btn-close{color:#f75357}.algolia-hit-item-link em{color:#f75357}.ais-Pagination-item a{color:#f75357}.abstract-content code,.article-entry code{background:#282c34}.archive-post-item:hover{border-left-color:#f75357}.archive-post-item:hover .archive-post-date,.archive-post-item:hover .archive-post-title{color:#f75357}.site-search .search-icon{color:#f75357}.archive-year,.total-archive{color:#f75357}.sidebar-tag-name:hover,.sidebar-category-name:hover{border-color:#f75357;color:#f75357}.sidebar-label-focus{border-color:#f75357;color:#f75357}.sidebar-tabs::after{background-color:#f75357}.index-post{background-color:#181818;margin-bottom:1rem}.index-post .abstract-content{color:rgba(255,255,255,0.6)}.abstract-title{color:rgba(255,255,255,0.87)}.abstract-title:hover{color:#f75357}.index-post .abstract-read-more-button a{color:rgba(255,255,255,0.38)}.index-post .abstract-read-more-button a:hover{color:#f75357}.abstract-post-meta{color:rgba(255,255,255,0.38)}.abstract-post-meta a{color:rgba(255,255,255,0.38)}.abstract-post-meta .post-tag::after{content:'';position:absolute;left:calc((100% - 98%) / 2);bottom:-15%;transition:all 0.15s ease-in;width:98%;height:2px;transform:translate(0, 0);background-color:rgba(255,255,255,0.38);opacity:0}.abstract-post-meta .post-tag:hover::after{transform:translate(0, -2px);opacity:1}.index-post-divider{display:none}.anchorjs-archer{color:#f75357}.article-entry{background-color:#181818}.abstract-content,.article-entry{color:rgba(255,255,255,0.87)}.abstract-content blockquote,.article-entry blockquote{background-color:#1e1e1e;border-left-color:#f75357}.abstract-content .table-container table,.abstract-content>table,.article-entry .table-container table,.article-entry>table{border-color:#1e1e1e;box-shadow:2px 2px 2px rgba(255,255,255,0.125)}.abstract-content .table-container table thead tr,.abstract-content>table thead tr,.article-entry .table-container table thead tr,.article-entry>table thead tr{background:#1e1e1e}.abstract-content .table-container table tbody tr:hover,.abstract-content>table tbody tr:hover,.article-entry .table-container table tbody tr:hover,.article-entry>table tbody tr:hover{background:#242424}.abstract-content .table-container table td,.abstract-content .table-container table th,.abstract-content>table td,.abstract-content>table th,.article-entry .table-container table td,.article-entry .table-container table th,.article-entry>table td,.article-entry>table th{border-color:#2a2a2a}.abstract-content a,.article-entry a{color:#f75357}.abstract-content a:hover,.article-entry a:hover{border-bottom-color:#f75357}.license-wrapper{background-color:#181818}.license-wrapper{color:rgba(255,255,255,0.87)}.license-wrapper a{color:#f75357}.toc-wrapper .toc-active{color:#f75357}.toc-wrapper a{color:#777}.toc-wrapper a:hover{color:#f75357}.toc-catalog:hover{color:#f75357}.post-paginator .nextTitle,.post-paginator .prevTitle{color:rgba(255,255,255,0.38)}.post-paginator .nextTitle:hover,.post-paginator .prevTitle:hover{color:#f75357}.post-paginator .nextSlogan,.post-paginator .prevSlogan{color:rgba(255,255,255,0.6)}#gitalk-container *{color:rgba(255,255,255,0.87)}#gitalk-container a{color:#f75357 !important}#gitalk-container a:hover{color:#fcb4b6 !important;border-color:#fcb4b6 !important}#gitalk-container .gt-svg svg{fill:#f75357 !important}#gitalk-container .gt-spinner::before{border-color:#fff !important;border-top-color:#f75357 !important}#gitalk-container .gt-btn{background-color:#f75357 !important;border-color:#f75357 !important;color:#fff !important}#gitalk-container .gt-btn-login:hover{background-color:#fcb4b6 !important;border-color:#fcb4b6 !important}#gitalk-container .gt-btn-preview{background-color:#fff !important;color:#f75357 !important}#gitalk-container .gt-btn-preview:hover{background-color:#f2f2f2 !important;border-color:#fcb4b6 !important}#gitalk-container .gt-btn-preview .gt-btn-text{color:#f75357 !important}#gitalk-container .gt-btn-public:hover{background-color:#fcb4b6 !important;border-color:#fcb4b6 !important}#gitalk-container .gt-link{border-bottom-color:#f75357 !important}#gitalk-container .gt-user .is--poping .gt-ico svg{fill:#f75357 !important}#gitalk-container .gt-popup .gt-action.is--active:before{background:#f75357 !important}#gitalk-container .gt-header-controls-tip{color:#f75357 !important}#gitalk-container .gt-comment-username{color:#f75357 !important}
+:root {
+    --base-font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial,
+        'PingFang SC', 'Hiragino Sans GB', STHeiti, 'Microsoft YaHei',
+        'Microsoft JhengHei', 'Source Han Sans SC', 'Noto Sans CJK SC',
+        'Source Han Sans CN', 'Noto Sans SC', 'Source Han Sans TC',
+        'Noto Sans CJK TC', 'WenQuanYi Micro Hei', SimSun, sans-serif
+}
+
+@font-face {
+    font-family: 'iconfont-archer';
+    src: url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.eot");
+    src: url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.eot?#iefix") format("embedded-opentype"), url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.woff") format("woff"), url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.ttf") format("truetype"), url("//at.alicdn.com/t/font_327081_s1wbjxwfu9c.svg#iconfont-archer") format("svg")
+}
+
+.iconfont-archer {
+    font-family: 'iconfont-archer' !important;
+    font-size: 1rem;
+    font-style: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale
+}
+
+body {
+    background-color: #121212
+}
+
+.background-holder {
+    background-color: #121212
+}
+
+.container {
+    background-color: #121212
+}
+
+::-moz-selection {
+    background: #f75357;
+    color: snow
+}
+
+::selection {
+    background: #f75357;
+    color: snow
+}
+
+.note {
+    background-color: #1e1e1e !important
+}
+
+.back-top {
+    border-color: rgba(255, 255, 255, 0.87);
+    background-color: rgba(18, 18, 18, 0.8);
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.back-top:hover {
+    background-color: rgba(255, 255, 255, 0.87);
+    color: #121212
+}
+
+.back-top-rounded {
+    color: #fff;
+    background-color: #121212
+}
+
+.back-top-rounded:hover {
+    color: #333
+}
+
+.footer {
+    background-color: #121212
+}
+
+.copyright a {
+    color: #f75357
+}
+
+#busuanzi_container_site_pv,
+#busuanzi_container_site_uv {
+    color: rgba(255, 255, 255, 0.38)
+}
+
+.read-progress {
+    background-color: rgba(255, 255, 255, 0.6)
+}
+
+.read-progress-feature {
+    background-color: #f75357
+}
+
+.banner {
+    border-bottom-color: rgba(255, 255, 255, 0.87);
+    background-color: rgba(0, 0, 0, 0.8)
+}
+
+.banner .blog-title a {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.banner .blog-title a:hover {
+    color: #f75357
+}
+
+.banner .post-title a {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.banner.banner-clean {
+    background-color: rgba(0, 0, 0, 0.9)
+}
+
+.header-sidebar-menu {
+    border-color: #fff;
+    color: #fff
+}
+
+.header-sidebar-menu:hover {
+    background-color: #fff;
+    color: #000
+}
+
+.header-sidebar-menu-rounded:hover {
+    background-color: transparent;
+    color: #f75357
+}
+
+.header-sidebar-menu-black {
+    color: rgba(255, 255, 255, 0.87);
+    background-color: #121212;
+    border-color: rgba(255, 255, 255, 0.87)
+}
+
+.header-sidebar-menu-black:hover {
+    background-color: rgba(255, 255, 255, 0.87);
+    color: #121212
+}
+
+.header-actions .home-link a:hover {
+    color: #f75357
+}
+
+.profile {
+    color: #777;
+    border-color: rgba(255, 255, 255, 0.1)
+}
+
+.profile-avatar {
+    border-color: rgba(255, 255, 255, 0.1)
+}
+
+.profile-name {
+    color: #ddd
+}
+
+.profile-social {
+    border-color: rgba(255, 255, 255, 0.1)
+}
+
+.friends {
+    border-color: rgba(255, 255, 255, 0.1)
+}
+
+.friends a {
+    color: #777
+}
+
+.friends a:hover {
+    color: #f75357
+}
+
+.profile-link-item {
+    border-color: rgba(255, 255, 255, 0.1)
+}
+
+.profile-link-item a {
+    color: #777
+}
+
+.profile-link-item a:hover {
+    color: #f75357
+}
+
+.popup {
+    background: #121212;
+    color: #e1e1e1;
+    box-shadow: 0px 0px 10px rgba(255, 255, 255, 0.5)
+}
+
+.algolia-search {
+    border-bottom-color: #222;
+    background-color: #181818
+}
+
+.algolia-search-input input {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.algolia-hit-item:hover {
+    border-bottom: 1px solid;
+    background-color: #181818
+}
+
+.algolia-hit-item-link {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.popup-btn-close {
+    color: #f75357
+}
+
+.algolia-hit-item-link em {
+    color: #f75357
+}
+
+.ais-Pagination-item a {
+    color: #f75357
+}
+
+.abstract-content code,
+.article-entry code {
+    background: #282c34
+}
+
+.archive-post-item:hover {
+    border-left-color: #f75357
+}
+
+.archive-post-item:hover .archive-post-date,
+.archive-post-item:hover .archive-post-title {
+    color: #f75357
+}
+
+.site-search .search-icon {
+    color: #f75357
+}
+
+.archive-year,
+.total-archive {
+    color: #f75357
+}
+
+.sidebar-tag-name:hover,
+.sidebar-category-name:hover {
+    border-color: #f75357;
+    color: #f75357
+}
+
+.sidebar-label-focus {
+    border-color: #f75357;
+    color: #f75357
+}
+
+.sidebar-tabs::after {
+    background-color: #f75357
+}
+
+.index-post {
+    background-color: #181818;
+    margin-bottom: 1rem
+}
+
+.index-post .abstract-content {
+    color: rgba(255, 255, 255, 0.6)
+}
+
+.abstract-title {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.abstract-title:hover {
+    color: #f75357
+}
+
+.index-post .abstract-read-more-button a {
+    color: rgba(255, 255, 255, 0.38)
+}
+
+.index-post .abstract-read-more-button a:hover {
+    color: #f75357
+}
+
+.abstract-post-meta {
+    color: rgba(255, 255, 255, 0.38)
+}
+
+.abstract-post-meta a {
+    color: rgba(255, 255, 255, 0.38)
+}
+
+.abstract-post-meta .post-tag::after {
+    content: '';
+    position: absolute;
+    left: calc((100% - 98%) / 2);
+    bottom: -15%;
+    transition: all 0.15s ease-in;
+    width: 98%;
+    height: 2px;
+    transform: translate(0, 0);
+    background-color: rgba(255, 255, 255, 0.38);
+    opacity: 0
+}
+
+.abstract-post-meta .post-tag:hover::after {
+    transform: translate(0, -2px);
+    opacity: 1
+}
+
+.index-post-divider {
+    display: none
+}
+
+.anchorjs-archer {
+    color: #f75357
+}
+
+.article-entry {
+    background-color: #181818
+}
+
+.abstract-content,
+.article-entry {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.abstract-content blockquote,
+.article-entry blockquote {
+    background-color: #1e1e1e;
+    border-left-color: #f75357
+}
+
+.abstract-content .table-container table,
+.abstract-content>table,
+.article-entry .table-container table,
+.article-entry>table {
+    border-color: #1e1e1e;
+    box-shadow: 2px 2px 2px rgba(255, 255, 255, 0.125)
+}
+
+.abstract-content .table-container table thead tr,
+.abstract-content>table thead tr,
+.article-entry .table-container table thead tr,
+.article-entry>table thead tr {
+    background: #1e1e1e
+}
+
+.abstract-content .table-container table tbody tr:hover,
+.abstract-content>table tbody tr:hover,
+.article-entry .table-container table tbody tr:hover,
+.article-entry>table tbody tr:hover {
+    background: #242424
+}
+
+.abstract-content .table-container table td,
+.abstract-content .table-container table th,
+.abstract-content>table td,
+.abstract-content>table th,
+.article-entry .table-container table td,
+.article-entry .table-container table th,
+.article-entry>table td,
+.article-entry>table th {
+    border-color: #2a2a2a
+}
+
+.abstract-content a,
+.article-entry a {
+    color: #f75357
+}
+
+.abstract-content a:hover,
+.article-entry a:hover {
+    border-bottom-color: #f75357
+}
+
+.license-wrapper {
+    background-color: #181818
+}
+
+.license-wrapper {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+.license-wrapper a {
+    color: #f75357
+}
+
+.toc-wrapper .toc-active {
+    color: #f75357
+}
+
+.toc-wrapper a {
+    color: #777
+}
+
+.toc-wrapper a:hover {
+    color: #f75357
+}
+
+.toc-catalog:hover {
+    color: #f75357
+}
+
+.post-paginator .nextTitle,
+.post-paginator .prevTitle {
+    color: rgba(255, 255, 255, 0.38)
+}
+
+.post-paginator .nextTitle:hover,
+.post-paginator .prevTitle:hover {
+    color: #f75357
+}
+
+.post-paginator .nextSlogan,
+.post-paginator .prevSlogan {
+    color: rgba(255, 255, 255, 0.6)
+}
+
+#gitalk-container * {
+    color: rgba(255, 255, 255, 0.87)
+}
+
+#gitalk-container textarea,
+#gitalk-container .gt-header-preview *,
+#gitalk-container .gt-comment-content * {
+    color: #000;
+}
+
+#gitalk-container a {
+    color: #f75357 !important
+}
+
+#gitalk-container a:hover {
+    color: #fcb4b6 !important;
+    border-color: #fcb4b6 !important
+}
+
+#gitalk-container .gt-svg svg {
+    fill: #f75357 !important
+}
+
+#gitalk-container .gt-spinner::before {
+    border-color: #fff !important;
+    border-top-color: #f75357 !important
+}
+
+#gitalk-container .gt-btn {
+    background-color: #f75357 !important;
+    border-color: #f75357 !important;
+    color: #fff !important
+}
+
+#gitalk-container .gt-btn-login:hover {
+    background-color: #fcb4b6 !important;
+    border-color: #fcb4b6 !important
+}
+
+#gitalk-container .gt-btn-preview {
+    background-color: #fff !important;
+    color: #f75357 !important
+}
+
+#gitalk-container .gt-btn-preview:hover {
+    background-color: #f2f2f2 !important;
+    border-color: #fcb4b6 !important
+}
+
+#gitalk-container .gt-btn-preview .gt-btn-text {
+    color: #f75357 !important
+}
+
+#gitalk-container .gt-btn-public:hover {
+    background-color: #fcb4b6 !important;
+    border-color: #fcb4b6 !important
+}
+
+#gitalk-container .gt-link {
+    border-bottom-color: #f75357 !important
+}
+
+#gitalk-container .gt-user .is--poping .gt-ico svg {
+    fill: #f75357 !important
+}
+
+#gitalk-container .gt-popup .gt-action.is--active:before {
+    background: #f75357 !important
+}
+
+#gitalk-container .gt-header-controls-tip {
+    color: #f75357 !important
+}
+
+#gitalk-container .gt-comment-username {
+    color: #f75357 !important
+}
 
 /*# sourceMappingURL=dark.css.map */


### PR DESCRIPTION
When you use gitalk in archer's dark mode, the textarea, preview container and the comment content container all have similar color and background color setting. This makes it very hard to see the text.

I have reformatted the `dark.css` under `source\css`.
The lines that are really changed are 420 - 424.