### PR TITLE
fix: category not shown if there are no tags

### DIFF
--- a/layout/_partial/base-background-image.ejs
+++ b/layout/_partial/base-background-image.ejs
@@ -53,7 +53,7 @@
         <% if(is_post()) { %>
             <div class="post-intros">
                 <!-- 文章页标签  -->
-                <% if(page.tags.length) { %>
+                <% if(page.tags.length || page.categories) { %>
                     <%- partial('base-title-tags', {
                         currPost: page,
                         className: 'post-intro-tags'}) %>


### PR DESCRIPTION
If there is only tags but not catogory specified by the blogger in the front-matter section, the category is not shown in hexo.

For example, I wrote a post with front-matter section as below.
![image](https://user-images.githubusercontent.com/62323571/196029472-0a75375f-a199-4d71-ad9f-a90b3436ae9b.png)

Before:
![image](https://user-images.githubusercontent.com/62323571/196029485-b8f173ea-44b6-4142-9385-b17a62815116.png)

After:
![image](https://user-images.githubusercontent.com/62323571/196029518-edea1ea3-a779-45e6-930e-b86227d17e8f.png)
