### PR TITLE
fix: friend link a tag target typo

### DIFF
--- a/layout/_partial/base-profile.ejs
+++ b/layout/_partial/base-profile.ejs
@@ -22,7 +22,7 @@
             <% for (name in theme.friends) { %>
                 <% if(theme.friends[name]) { %>
                     <span>
-                        <a href="<%- theme.friends[name] %>" target="_black"><%- name %></a>
+                        <a href="<%- theme.friends[name] %>" target="_blank"><%- name %></a>
                     </span>
                 <% } %>
             <% } %>


### PR DESCRIPTION
**_black** should be **_blank**, otherwise weird things happen.
![image](https://user-images.githubusercontent.com/62323571/201475028-2a290731-f4db-4333-a6b1-94f3a3e96056.png)
![image](https://user-images.githubusercontent.com/62323571/201474993-ea0aca8c-a072-48a5-8e94-e0191efe0299.png)
