### PR TITLE
MOD: migrate GoogleAnalytics to gtag.js

### DIFF
--- a/layout/_partial/base-head.ejs
+++ b/layout/_partial/base-head.ejs
@@ -68,17 +68,16 @@
             })();
         </script>
     <% } %>
-    <!-- 谷歌统计  -->
+    <!-- Google tag (gtag.js) -->
     <% if (theme.google_analytics) { %>
+        <script async src="https://www.googletagmanager.com/gtag/js?id=<%- theme.google_analytics %>"></script>
         <script>
-            (function (i, s, o, g, r, a, m) {
-                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-                }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-            ga('create', '<%- theme.google_analytics %>', 'auto');
-            ga('send', 'pageview');
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '<%- theme.google_analytics %>');
         </script>
     <% } %>
+
 </head>


### PR DESCRIPTION
> Google官方也在强烈建议企业尽快完成Universal Analytics到Google Analytics 4的迁移，因为UA在2023年7月之后不再进行数据收集。

ref: https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs?hl=zh-cn

复用 Config 中的 google_analytics 字段，但是需要更新配置，UA 和 GA4 的 TagID 不通用。