### PR TITLE
Modify the style of the post navigation title.

### DIFF
--- a/src/scss/_partial/_post-page.scss
+++ b/src/scss/_partial/_post-page.scss
@@ -204,7 +204,6 @@
 
   .nextTitle,
   .prevTitle {
-    font-size: 1.2rem;
     color: #ccc;
     &:hover {
       color: $feature-color;


### PR DESCRIPTION
Modify the style of the post navigation title: Remove font-size:1.2rem from the .nextTitle and prevTitle style classes.

Since article titles are usually quite long, changing to the normal font size is less likely to cause line breaks.

-----------

修改帖子导航标题的样式：移除 .nextTitle, prevTitle 样式类中的 font-size:1.2rem。
因为文章的标题通常较长，改为常规字体大小不容易导致换行。